### PR TITLE
Changes to work with pymongo 2.4 or higher which is required for MongoDB 2.2

### DIFF
--- a/minimongo/model.py
+++ b/minimongo/model.py
@@ -5,7 +5,7 @@ import re
 from bson import DBRef, ObjectId
 from minimongo.collection import DummyCollection
 from minimongo.options import _Options
-from pymongo import Connection
+from pymongo import MongoClient as Connection
 
 
 class ModelBase(type):

--- a/minimongo/model.py
+++ b/minimongo/model.py
@@ -58,7 +58,9 @@ class ModelBase(type):
             # creates :class:`pymongo.connection.Connection` object without
             # establishing connection. It's required if there is no running
             # mongodb at this time but we want to create :class:`Model`.
-            connection = Connection(*hostport, _connect=False)
+            # False option doesn't work with pymongo 2.4 using master/slave
+            # cluster
+            connection = Connection(*hostport)
             mcs._connections[hostport] = connection
 
         new_class._meta = options

--- a/setup.py
+++ b/setup.py
@@ -43,12 +43,12 @@ class PyTest(Command):
 requires = ["pymongo"]
 
 setup(name="minimongo",
-      version="0.2.6",
+      version="0.2.8b1",
       packages=find_packages(),
       cmdclass={"test": PyTest},
       platforms=["any"],
 
-      install_requires = ["pymongo>=1.9"],
+      install_requires = ["pymongo>=2.4"],
       zip_safe=False,
       include_package_data=True,
 


### PR DESCRIPTION
1. Removed _connect=false - For pymongo 2.4 or above, connection fails if you have replicaset cluster. Moreover I don't understand why you would want the models with out having mongo running.

2. Changed the deprecated Connection module to MongoClient

3. Bumped the version to internal number so that it would be easy upgrade if there is 0.2.9 GA

4 Changed pymongo required version to >= 2.4