### PR TITLE
Maintain a valid state in event of IOError 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,9 @@ Example
 -------
 
 Here's a very brief example of creating an object, querying for it, modifying
-a field, and then saving it back again::
+a field, and then saving it back again:
+
+.. code:: python
 
     from minimongo import Model, Index
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ DESCRIPTION = "Minimal database Model management for MongoDB"
 try:
     LONG_DESCRIPTION = open(os.path.join(here, "README.rst")).read()
 except IOError:
-    pass
+    print("Warning: IOError raised: cannot open README.rst.")
+    LONG_DESCRIPTION = DESCRIPTION
 
 
 CLASSIFIERS = (


### PR DESCRIPTION
Installation died on me because LONG_DESCRIPTION wasn't defined. It was defined only in the `try` portion of `setup.py`, with `except IOError` doing nothing (`pass`). So then later of course `long_description=LONG_DESCRIPTION` threw an error.

To make it work, I just aliased `LONG_DESCRIPTION` to `DESCRIPTION` when the `IOError` is raised. Also printed a warning. Which doesn't feel like good form, but importing logging felt like overkill. Maybe doing no warnings is the way to go?